### PR TITLE
Fix escaping issue on production mode

### DIFF
--- a/view/frontend/templates/footer/zopim.phtml
+++ b/view/frontend/templates/footer/zopim.phtml
@@ -2,8 +2,7 @@
 /**
  * @var $block \Vendic\Zopim\Block\View
  */
-?>
-<?php if ($block->config->getIsEnabled() && !empty($block->config->getZopimId())) : ?>
+if ($block->config->getIsEnabled() && !empty($block->config->getZopimId())) : ?>
     <?php if ($block->config->getCookiesEnabled()) : ?>
         <script>
             require([
@@ -13,12 +12,8 @@
             ], function ($) {
                 $(document).ready(function () {
 
-                    var cookieName = "<?php echo $block->config->getExpectedCookieName() ?>"
-                    var cookieValue = "<?php echo $block->config->getExpectedCookieValue() ?>"
-                    
-                    console.log(cookieName);
-                    console.log(cookieValue);
-                    console.log($.cookie(cookieValue));
+                    var cookieName = "<?= $block->escapeHtmlAttr($block->config->getExpectedCookieName()) ?>"
+                    var cookieValue = "<?= $block->escapeHtmlAttr($block->config->getExpectedCookieValue()) ?>"
 
                     if ($.cookie(cookieName) === cookieValue) {
 
@@ -42,14 +37,14 @@
                                     z.set._ = [];
                                     $.async = !0;
                                     $.setAttribute("charset", "utf-8");
-                                      $.src = "\/\/v2.zopim.com\/?<?= $block->escapeHtmlAttr( $block->config->getZopimId()); ?>";
+                                    $.src = "\/\/v2.zopim.com\/?<?= $block->escapeHtmlAttr($block->config->getZopimId()); ?>";
                                     z.t = +new Date;
                                     $.type = "text/javascript";
                                     e.parentNode.insertBefore($, e)
                                 })(document, "script");
                             }
 
-                        }, <?php echo $block->config->getDelay() ?>);
+                        }, <?= $block->escapeHtmlAttr($block->config->getDelay()); ?>);
 
                     }
 
@@ -83,14 +78,14 @@
                                 z.set._ = [];
                                 $.async = !0;
                                 $.setAttribute("charset", "utf-8");
-                                  $.src = "\/\/v2.zopim.com\/?<?= $block->escapeHtmlAttr( $block->config->getZopimId()); ?>";
+                                $.src = "\/\/v2.zopim.com\/?<?= $block->escapeHtmlAttr($block->config->getZopimId()); ?>";
                                 z.t = +new Date;
                                 $.type = "text/javascript";
                                 e.parentNode.insertBefore($, e)
                             })(document, "script");
                         }
 
-                    }, <?php echo $block->config->getDelay() ?>);
+                    },  <?= $block->escapeHtmlAttr($block->config->getDelay()); ?>);
 
                 });
             });

--- a/view/frontend/templates/footer/zopim.phtml
+++ b/view/frontend/templates/footer/zopim.phtml
@@ -12,8 +12,8 @@ if ($block->config->getIsEnabled() && !empty($block->config->getZopimId())) : ?>
             ], function ($) {
                 $(document).ready(function () {
 
-                    var cookieName = "<?= $block->escapeHtmlAttr($block->config->getExpectedCookieName()) ?>"
-                    var cookieValue = "<?= $block->escapeHtmlAttr($block->config->getExpectedCookieValue()) ?>"
+                    var cookieName = "<?= $block->escapeJs($block->config->getExpectedCookieName()) ?>"
+                    var cookieValue = "<?= $block->escapeJs($block->config->getExpectedCookieValue()) ?>"
 
                     if ($.cookie(cookieName) === cookieValue) {
 
@@ -37,14 +37,14 @@ if ($block->config->getIsEnabled() && !empty($block->config->getZopimId())) : ?>
                                     z.set._ = [];
                                     $.async = !0;
                                     $.setAttribute("charset", "utf-8");
-                                    $.src = "\/\/v2.zopim.com\/?<?= $block->escapeHtmlAttr($block->config->getZopimId()); ?>";
+                                    $.src = "<?= $block->escapeJs("//v2.zopim.com/?" . $block->config->getZopimId()); ?>";
                                     z.t = +new Date;
                                     $.type = "text/javascript";
                                     e.parentNode.insertBefore($, e)
                                 })(document, "script");
                             }
 
-                        }, <?= $block->escapeHtmlAttr($block->config->getDelay()); ?>);
+                        }, <?= $block->escapeJs($block->config->getDelay()); ?>);
 
                     }
 
@@ -78,14 +78,14 @@ if ($block->config->getIsEnabled() && !empty($block->config->getZopimId())) : ?>
                                 z.set._ = [];
                                 $.async = !0;
                                 $.setAttribute("charset", "utf-8");
-                                $.src = "\/\/v2.zopim.com\/?<?= $block->escapeHtmlAttr($block->config->getZopimId()); ?>";
+                                $.src = "<?= $block->escapeJs("//v2.zopim.com/?" . $block->config->getZopimId()); ?>";
                                 z.t = +new Date;
                                 $.type = "text/javascript";
                                 e.parentNode.insertBefore($, e)
                             })(document, "script");
                         }
 
-                    },  <?= $block->escapeHtmlAttr($block->config->getDelay()); ?>);
+                    },  <?= $block->escapeJs($block->config->getDelay()); ?>);
 
                 });
             });

--- a/view/frontend/templates/footer/zopim.phtml
+++ b/view/frontend/templates/footer/zopim.phtml
@@ -42,7 +42,7 @@
                                     z.set._ = [];
                                     $.async = !0;
                                     $.setAttribute("charset", "utf-8");
-                                    $.src = "//v2.zopim.com/?<?php echo $block->config->getZopimId() ?>";
+                                      $.src = "\/\/v2.zopim.com\/?<?= $block->escapeHtmlAttr( $block->config->getZopimId()); ?>";
                                     z.t = +new Date;
                                     $.type = "text/javascript";
                                     e.parentNode.insertBefore($, e)
@@ -83,7 +83,7 @@
                                 z.set._ = [];
                                 $.async = !0;
                                 $.setAttribute("charset", "utf-8");
-                                $.src = "//v2.zopim.com/?<?php echo $block->config->getZopimId() ?>";
+                                  $.src = "\/\/v2.zopim.com\/?<?= $block->escapeHtmlAttr( $block->config->getZopimId()); ?>";
                                 z.t = +new Date;
                                 $.type = "text/javascript";
                                 e.parentNode.insertBefore($, e)


### PR DESCRIPTION
We used this module but in production mode on the server had issues with the $.url =" been removed from the script due to the renderSecureHtml class (related to https://github.com/magento/magento2/issues/30524)

The following MR has the fix to make it work again